### PR TITLE
Removed '.only' from the search feature test case

### DIFF
--- a/test/specs/e2e/search.e2e.js
+++ b/test/specs/e2e/search.e2e.js
@@ -1,8 +1,8 @@
 import { browser, expect } from '@wdio/globals'
 
-describe.only('Search feature', () => {
+describe('Search feature', () => {
     
-    it.only('Should search for values using keyboard press', async () => {
+    it('Should search for values using keyboard press', async () => {
         const searchText = 'bank'
         await browser.url('http://zero.webappsecurity.com/index.html')
         


### PR DESCRIPTION
Removed the .only modifier from the test case to ensure all test cases in the suite are executed.
